### PR TITLE
feat: 히라가나 문장 테스트 기능 및 사이드바 리셋 기능 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 import { Menu } from 'lucide-react';
 import QuizContainer from './components/quiz/QuizContainer';
 import LearningPage from './components/learning/LearningPage';
@@ -11,6 +11,8 @@ import styles from './App.module.css';
 
 function App() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [resetKey, setResetKey] = useState(0);
+  const location = useLocation();
 
   const toggleSidebar = () => {
     setSidebarOpen(!sidebarOpen);
@@ -20,10 +22,14 @@ function App() {
     setSidebarOpen(false);
   };
 
+  const handleReset = () => {
+    setResetKey(prev => prev + 1);
+  };
+
   return (
     <div className={styles.app}>
       {/* 사이드바 컴포넌트 */}
-      <Sidebar isOpen={sidebarOpen} onClose={closeSidebar} />
+      <Sidebar isOpen={sidebarOpen} onClose={closeSidebar} onReset={handleReset} />
 
       <header className={styles.appHeader}>
         {/* 햄버거 메뉴 버튼 */}
@@ -35,7 +41,7 @@ function App() {
       </header>
       
       <main className={styles.appMain}>
-        <Routes>
+        <Routes key={location.pathname + resetKey}>
           <Route path="/" element={<QuizContainer />} />
           <Route path="/quiz" element={<QuizContainer />} />
           <Route path="/learning" element={<LearningPage />} />
@@ -51,6 +57,8 @@ function App() {
             <a href="https://github.com/sinam7" target="_blank" rel="noopener noreferrer">
               GitHub
             </a>
+            <span> | </span>
+            <a href="https://sinam7.com" target="_blank" rel="noopener noreferrer">Home</a>
           </p>
         </div>
       </footer>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 import { Menu } from 'lucide-react';
 import QuizContainer from './components/quiz/QuizContainer';
 import LearningPage from './components/learning/LearningPage';
+import SentenceQuiz from './components/quiz/sentence/SentenceQuiz';
 import Settings from './components/settings/Settings';
 import Sidebar from './components/common/Sidebar';
 
@@ -38,6 +39,7 @@ function App() {
           <Route path="/" element={<QuizContainer />} />
           <Route path="/quiz" element={<QuizContainer />} />
           <Route path="/learning" element={<LearningPage />} />
+          <Route path="/sentence" element={<SentenceQuiz />} />
           <Route path="/settings" element={<Settings />} />
         </Routes>
       </main>

--- a/src/components/common/Sidebar.jsx
+++ b/src/components/common/Sidebar.jsx
@@ -4,12 +4,17 @@ import { X } from 'lucide-react';
 import { getSidebarMenuItems } from '../../config/routes';
 import styles from './Sidebar.module.css';
 
-const Sidebar = ({ isOpen, onClose }) => {
+const Sidebar = ({ isOpen, onClose, onReset }) => {
   const location = useLocation();
   const navigate = useNavigate();
 
   const handleNavigate = (path) => {
-    navigate(path);
+    // 현재 경로와 같은 경로로 이동하는 경우, 컴포넌트를 리셋
+    if (location.pathname === path) {
+      onReset(); // App.jsx의 resetKey를 업데이트하여 컴포넌트 리셋
+    } else {
+      navigate(path);
+    }
     onClose(); // 네비게이션 후 사이드바 닫기
   };
 

--- a/src/components/quiz/sentence/SentenceQuiz.jsx
+++ b/src/components/quiz/sentence/SentenceQuiz.jsx
@@ -1,0 +1,299 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { getAllHiraganaMap } from '../../../utils/hiraganaUtils';
+import styles from './SentenceQuiz.module.css';
+
+const SentenceQuiz = () => {
+  const [inputSentence, setInputSentence] = useState('');
+  const [currentQuiz, setCurrentQuiz] = useState(null);
+  const [quizCharacters, setQuizCharacters] = useState([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [userAnswer, setUserAnswer] = useState('');
+  const [score, setScore] = useState(0);
+  const [isQuizActive, setIsQuizActive] = useState(false);
+  const [showResult, setShowResult] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  
+  // 입력란 자동 포커스를 위한 ref
+  const answerInputRef = useRef(null);
+
+  // 문장에서 히라가나 문자들을 추출하고 퀴즈 생성
+  const generateQuizFromSentence = () => {
+    if (!inputSentence.trim()) {
+      alert('히라가나 문장을 입력해주세요!');
+      return;
+    }
+
+    const hiraganaMap = getAllHiraganaMap();
+    const characters = [];
+    
+    // 문장을 한 글자씩 분석하여 히라가나인지 확인
+    for (let i = 0; i < inputSentence.length; i++) {
+      const char = inputSentence[i];
+      
+      // 요음 체크 (2글자)
+      if (i < inputSentence.length - 1) {
+        const twoChar = inputSentence.slice(i, i + 2);
+        if (hiraganaMap[twoChar]) {
+          characters.push({
+            hiragana: twoChar,
+            romaji: hiraganaMap[twoChar],
+            position: i
+          });
+          i++; // 다음 글자 건너뛰기
+          continue;
+        }
+      }
+      
+      // 일반 히라가나 체크 (1글자)
+      if (hiraganaMap[char]) {
+        characters.push({
+          hiragana: char,
+          romaji: hiraganaMap[char],
+          position: i
+        });
+      }
+    }
+
+    if (characters.length === 0) {
+      alert('유효한 히라가나 문자가 없습니다!');
+      return;
+    }
+
+    // 문자 순서 섞기
+    const shuffledCharacters = [...characters].sort(() => Math.random() - 0.5);
+    
+    setQuizCharacters(shuffledCharacters);
+    setCurrentIndex(0);
+    setScore(0);
+    setIsQuizActive(true);
+    setShowResult(false);
+    setFeedback('');
+    setUserAnswer('');
+    
+    // 퀴즈 시작 후 잠깐 뒤에 포커스
+    setTimeout(() => {
+      if (answerInputRef.current) {
+        answerInputRef.current.focus();
+      }
+    }, 200);
+  };
+
+  // 현재 퀴즈 문제 설정
+  useEffect(() => {
+    if (isQuizActive && quizCharacters.length > 0 && currentIndex < quizCharacters.length) {
+      setCurrentQuiz(quizCharacters[currentIndex]);
+      setUserAnswer('');
+      setFeedback('');
+    }
+  }, [isQuizActive, quizCharacters, currentIndex]);
+
+  // 새 문제가 시작될 때 입력란에 자동 포커스
+  useEffect(() => {
+    if (currentQuiz && !feedback && answerInputRef.current) {
+      // 짧은 지연 후 포커스 (애니메이션 완료 후)
+      const timer = setTimeout(() => {
+        answerInputRef.current.focus();
+      }, 100);
+      
+      return () => clearTimeout(timer);
+    }
+  }, [currentQuiz, feedback]);
+
+  // 답안 제출
+  const handleSubmitAnswer = () => {
+    if (!userAnswer.trim()) {
+      setFeedback('답을 입력해주세요!');
+      return;
+    }
+
+    const isCorrect = userAnswer.toLowerCase().trim() === currentQuiz.romaji.toLowerCase();
+    
+    if (isCorrect) {
+      setScore(score + 1);
+      setFeedback('정답입니다! 🎉');
+    } else {
+      setFeedback(`틀렸습니다. 정답: ${currentQuiz.romaji}`);
+    }
+
+    // 1.5초 후 다음 문제로 이동
+    setTimeout(() => {
+      if (currentIndex + 1 < quizCharacters.length) {
+        setCurrentIndex(currentIndex + 1);
+      } else {
+        // 퀴즈 완료
+        setIsQuizActive(false);
+        setShowResult(true);
+      }
+    }, 1500);
+  };
+
+  // 퀴즈 재시작
+  const restartQuiz = () => {
+    setIsQuizActive(false);
+    setShowResult(false);
+    setCurrentIndex(0);
+    setScore(0);
+    setUserAnswer('');
+    setFeedback('');
+    setQuizCharacters([]);
+    setCurrentQuiz(null);
+  };
+
+  // Enter 키로 답안 제출
+  const handleKeyPress = (e) => {
+    if (e.key === 'Enter' && !showResult && currentQuiz) {
+      handleSubmitAnswer();
+    }
+  };
+
+  return (
+    <div className={styles.sentenceQuiz}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>히라가나 문장 테스트</h2>
+        <p className={styles.description}>
+          히라가나로 이루어진 문장을 입력하고, 각 문자의 로마자를 맞춰보세요!
+        </p>
+      </div>
+
+      {!isQuizActive && !showResult && (
+        <div className={styles.inputSection}>
+          <div className={styles.inputGroup}>
+            <label htmlFor="sentence" className={styles.label}>
+              히라가나 문장을 입력하세요:
+            </label>
+            <input
+              type="text"
+              id="sentence"
+              value={inputSentence}
+              onChange={(e) => setInputSentence(e.target.value)}
+              placeholder="예: おはよう、きょうはいいてんきですね"
+              className={styles.sentenceInput}
+            />
+            <button 
+              onClick={generateQuizFromSentence}
+              className={styles.startButton}
+              disabled={!inputSentence.trim()}
+            >
+              테스트 시작하기
+            </button>
+          </div>
+          
+          <div className={styles.exampleSection}>
+            <h3 className={styles.exampleTitle}>예시 문장:</h3>
+            <div className={styles.examples}>
+              <button 
+                onClick={() => setInputSentence('おはよう')}
+                className={styles.exampleButton}
+              >
+                おはよう
+              </button>
+              <button 
+                onClick={() => setInputSentence('きょうはいいてんきですね')}
+                className={styles.exampleButton}
+              >
+                きょうはいいてんきですね
+              </button>
+              <button 
+                onClick={() => setInputSentence('しゅくだいをしました')}
+                className={styles.exampleButton}
+              >
+                しゅくだいをしました
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {isQuizActive && currentQuiz && (
+        <div className={styles.quizSection}>
+          <div className={styles.progress}>
+            <span className={styles.progressText}>
+              {currentIndex + 1} / {quizCharacters.length}
+            </span>
+            <div className={styles.progressBar}>
+              <div 
+                className={styles.progressFill}
+                style={{ width: `${((currentIndex + 1) / quizCharacters.length) * 100}%` }}
+              ></div>
+            </div>
+          </div>
+
+          <div className={styles.questionCard}>
+            <h3 className={styles.questionTitle}>이 문자의 로마자는?</h3>
+            <div className={styles.hiraganaDisplay}>
+              {currentQuiz.hiragana}
+            </div>
+            
+            <div className={styles.answerSection}>
+              <input
+                ref={answerInputRef}
+                type="text"
+                value={userAnswer}
+                onChange={(e) => setUserAnswer(e.target.value)}
+                onKeyPress={handleKeyPress}
+                placeholder="로마자를 입력하세요"
+                className={styles.answerInput}
+                disabled={feedback !== ''}
+              />
+              <button 
+                onClick={handleSubmitAnswer}
+                className={styles.submitButton}
+                disabled={feedback !== '' || !userAnswer.trim()}
+              >
+                제출
+              </button>
+            </div>
+
+            {feedback && (
+              <div className={`${styles.feedback} ${feedback.includes('정답') ? styles.correct : styles.incorrect}`}>
+                {feedback}
+              </div>
+            )}
+          </div>
+
+          <div className={styles.scoreDisplay}>
+            현재 점수: {score} / {currentIndex + (feedback ? 1 : 0)}
+          </div>
+        </div>
+      )}
+
+      {showResult && (
+        <div className={styles.resultSection}>
+          <div className={styles.resultCard}>
+            <h3 className={styles.resultTitle}>테스트 완료!</h3>
+            <div className={styles.finalScore}>
+              최종 점수: {score} / {quizCharacters.length}
+              <span className={styles.percentage}>
+                ({Math.round((score / quizCharacters.length) * 100)}%)
+              </span>
+            </div>
+            
+            <div className={styles.resultMessage}>
+              {score === quizCharacters.length ? '완벽합니다! 🎉' :
+               score >= quizCharacters.length * 0.8 ? '잘했어요! 👏' :
+               score >= quizCharacters.length * 0.6 ? '조금 더 연습해보세요! 📚' :
+               '더 많은 연습이 필요해요! 💪'}
+            </div>
+
+            <div className={styles.resultButtons}>
+              <button 
+                onClick={restartQuiz}
+                className={styles.restartButton}
+              >
+                새 문장으로 다시 하기
+              </button>
+              <button 
+                onClick={generateQuizFromSentence}
+                className={styles.retryButton}
+              >
+                같은 문장으로 다시 하기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SentenceQuiz; 

--- a/src/components/quiz/sentence/SentenceQuiz.jsx
+++ b/src/components/quiz/sentence/SentenceQuiz.jsx
@@ -89,7 +89,7 @@ const SentenceQuiz = () => {
     setWasCorrect(isCorrect);
     
     if (isCorrect) {
-      setScore(score + 1);
+      setScore(prevScore => prevScore + 1);
       setFeedback('정답입니다! 🎉');
     } else {
       setFeedback(`틀렸습니다. 정답: ${currentQuiz.romaji}`);

--- a/src/components/quiz/sentence/SentenceQuiz.module.css
+++ b/src/components/quiz/sentence/SentenceQuiz.module.css
@@ -86,6 +86,17 @@
   cursor: not-allowed;
 }
 
+/* 에러 메시지 */
+.errorMessage {
+  background: var(--color-danger-light);
+  color: var(--color-danger);
+  padding: 0.8rem 1rem;
+  border-radius: 6px;
+  margin-top: 0.8rem;
+  font-size: 0.9rem;
+  border: 1px solid var(--color-danger-lighter);
+}
+
 /* 예시 섹션 */
 .exampleSection {
   border-top: 1px solid var(--color-border);

--- a/src/components/quiz/sentence/SentenceQuiz.module.css
+++ b/src/components/quiz/sentence/SentenceQuiz.module.css
@@ -1,0 +1,420 @@
+@import '../../../config/variables.css';
+
+.sentenceQuiz {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: var(--font-family);
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.title {
+  color: var(--color-text-primary);
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  font-weight: bold;
+}
+
+.description {
+  color: var(--color-text-secondary);
+  font-size: 1.1rem;
+  line-height: 1.5;
+}
+
+/* 입력 섹션 */
+.inputSection {
+  background: var(--color-surface);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: var(--shadow-light);
+  margin-bottom: 2rem;
+}
+
+.inputGroup {
+  margin-bottom: 2rem;
+}
+
+.label {
+  display: block;
+  color: var(--color-text-primary);
+  font-weight: 600;
+  margin-bottom: 0.8rem;
+  font-size: 1.1rem;
+}
+
+.sentenceInput {
+  width: 100%;
+  padding: 1rem;
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  font-size: 1.1rem;
+  font-family: 'Noto Sans JP', sans-serif;
+  transition: border-color 0.3s ease;
+  margin-bottom: 1rem;
+}
+
+.sentenceInput:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.startButton {
+  background: var(--gradient-primary);
+  color: white;
+  border: none;
+  padding: 1rem 2rem;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.3s ease;
+  width: 100%;
+}
+
+.startButton:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-medium);
+}
+
+.startButton:disabled {
+  background: var(--color-gray-300);
+  cursor: not-allowed;
+}
+
+/* 예시 섹션 */
+.exampleSection {
+  border-top: 1px solid var(--color-border);
+  padding-top: 1.5rem;
+}
+
+.exampleTitle {
+  color: var(--color-text-primary);
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
+.examples {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.exampleButton {
+  background: var(--color-gray-100);
+  border: 1px solid var(--color-border);
+  padding: 0.6rem 1rem;
+  border-radius: 6px;
+  font-family: 'Noto Sans JP', sans-serif;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.exampleButton:hover {
+  background: var(--color-primary);
+  color: white;
+  border-color: var(--color-primary);
+}
+
+/* 퀴즈 섹션 */
+.quizSection {
+  background: var(--color-surface);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: var(--shadow-light);
+}
+
+.progress {
+  margin-bottom: 2rem;
+}
+
+.progressText {
+  display: block;
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  margin-bottom: 0.8rem;
+}
+
+.progressBar {
+  width: 100%;
+  height: 8px;
+  background: var(--color-gray-200);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  background: var(--gradient-primary);
+  transition: width 0.3s ease;
+}
+
+.questionCard {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.questionTitle {
+  color: var(--color-text-primary);
+  font-size: 1.3rem;
+  margin-bottom: 1.5rem;
+  font-weight: 600;
+}
+
+.hiraganaDisplay {
+  font-size: 4rem;
+  font-family: 'Noto Sans JP', sans-serif;
+  color: var(--color-primary);
+  margin-bottom: 2rem;
+  font-weight: bold;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.answerSection {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+
+.answerInput {
+  padding: 1rem;
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  font-size: 1.2rem;
+  text-align: center;
+  font-weight: 600;
+  min-width: 200px;
+  transition: all 0.3s ease;
+}
+
+.answerInput:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 4px rgba(232, 165, 192, 0.3);
+  transform: scale(1.02);
+  transition: all 0.2s ease;
+}
+
+.answerInput:disabled {
+  background: var(--color-gray-100);
+  color: var(--color-text-secondary);
+}
+
+.submitButton {
+  background: var(--color-success);
+  color: white;
+  border: none;
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.submitButton:hover:not(:disabled) {
+  background: var(--color-success-dark);
+  transform: translateY(-1px);
+}
+
+.submitButton:disabled {
+  background: var(--color-gray-300);
+  cursor: not-allowed;
+}
+
+.feedback {
+  padding: 1rem;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.feedback.correct {
+  background: linear-gradient(135deg, #d4f6d4, #b8e6b8);
+  color: #2d5a2d;
+  border: 2px solid #4caf50;
+  box-shadow: 0 4px 12px rgba(76, 175, 80, 0.3);
+  animation: successPulse 0.6s ease-in-out;
+}
+
+.feedback.incorrect {
+  background: linear-gradient(135deg, #ffd4d4, #ffb8b8);
+  color: #8b2635;
+  border: 2px solid #f44336;
+  box-shadow: 0 4px 12px rgba(244, 67, 54, 0.3);
+  animation: errorShake 0.6s ease-in-out;
+}
+
+@keyframes successPulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+@keyframes errorShake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  75% { transform: translateX(5px); }
+}
+
+.scoreDisplay {
+  text-align: center;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  padding: 1rem;
+  background: var(--color-gray-50);
+  border-radius: 8px;
+}
+
+/* 결과 섹션 */
+.resultSection {
+  background: var(--color-surface);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: var(--shadow-light);
+  text-align: center;
+}
+
+.resultCard {
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+.resultTitle {
+  color: var(--color-text-primary);
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+  font-weight: bold;
+}
+
+.finalScore {
+  font-size: 2.5rem;
+  font-weight: bold;
+  color: var(--color-primary);
+  margin-bottom: 1rem;
+}
+
+.percentage {
+  font-size: 1.5rem;
+  color: var(--color-text-secondary);
+  font-weight: normal;
+  margin-left: 0.5rem;
+}
+
+.resultMessage {
+  font-size: 1.3rem;
+  color: var(--color-text-secondary);
+  margin-bottom: 2rem;
+  font-weight: 600;
+}
+
+.resultButtons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.restartButton,
+.retryButton {
+  padding: 1rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-width: 180px;
+}
+
+.restartButton {
+  background: var(--gradient-primary);
+  color: white;
+}
+
+.restartButton:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-medium);
+}
+
+.retryButton {
+  background: var(--color-gray-100);
+  color: var(--color-text-primary);
+  border: 2px solid var(--color-border);
+}
+
+.retryButton:hover {
+  background: var(--color-gray-200);
+  border-color: var(--color-primary);
+}
+
+/* 반응형 디자인 */
+@media (max-width: 768px) {
+  .sentenceQuiz {
+    padding: 1rem;
+  }
+  
+  .title {
+    font-size: 1.6rem;
+  }
+  
+  .description {
+    font-size: 1rem;
+  }
+  
+  .hiraganaDisplay {
+    font-size: 3rem;
+  }
+  
+  .answerSection {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  
+  .answerInput {
+    min-width: 100%;
+  }
+  
+  .examples {
+    flex-direction: column;
+  }
+  
+  .exampleButton {
+    width: 100%;
+  }
+  
+  .resultButtons {
+    flex-direction: column;
+  }
+  
+  .restartButton,
+  .retryButton {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .finalScore {
+    font-size: 2rem;
+  }
+  
+  .percentage {
+    font-size: 1.2rem;
+  }
+  
+  .hiraganaDisplay {
+    font-size: 2.5rem;
+  }
+} 

--- a/src/components/quiz/sentence/SentenceQuiz.module.css
+++ b/src/components/quiz/sentence/SentenceQuiz.module.css
@@ -60,7 +60,7 @@
 .sentenceInput:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 3px var(--color-primary-focus-shadow);
 }
 
 .startButton {
@@ -210,7 +210,7 @@
 .answerInput:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 4px rgba(232, 165, 192, 0.3);
+  box-shadow: 0 0 0 4px var(--color-primary-light);
   transform: scale(1.02);
   transition: all 0.2s ease;
 }
@@ -252,18 +252,18 @@
 }
 
 .feedback.correct {
-  background: linear-gradient(135deg, #d4f6d4, #b8e6b8);
-  color: #2d5a2d;
-  border: 2px solid #4caf50;
-  box-shadow: 0 4px 12px rgba(76, 175, 80, 0.3);
+  background: var(--color-feedback-correct-bg);
+  color: var(--color-feedback-correct-text);
+  border: 2px solid var(--color-feedback-correct-border);
+  box-shadow: 0 4px 12px var(--color-feedback-correct-shadow);
   animation: successPulse 0.6s ease-in-out;
 }
 
 .feedback.incorrect {
-  background: linear-gradient(135deg, #ffd4d4, #ffb8b8);
-  color: #8b2635;
-  border: 2px solid #f44336;
-  box-shadow: 0 4px 12px rgba(244, 67, 54, 0.3);
+  background: var(--color-feedback-incorrect-bg);
+  color: var(--color-feedback-incorrect-text);
+  border: 2px solid var(--color-feedback-incorrect-border);
+  box-shadow: 0 4px 12px var(--color-feedback-incorrect-shadow);
   animation: errorShake 0.6s ease-in-out;
 }
 

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -1,7 +1,7 @@
 // 각 경로별 설정 관리
 export const routeConfig = {
   '/': {
-    name: '퀴즈 시작',
+    name: '히라가나 퀴즈',
     showInSidebar: true,
     icon: '🏠',
     component: 'HiraganaSelector',
@@ -16,7 +16,7 @@ export const routeConfig = {
   },
   '/learning': {
     name: '학습',
-    showInSidebar: true,
+    showInSidebar: false,
     icon: '📚',
     component: 'LearningPage',
     description: '히라가나 연상 학습을 위한 페이지'
@@ -41,8 +41,6 @@ export const routeConfig = {
 export const getCurrentRouteConfig = (pathname) => {
   return routeConfig[pathname] || {};
 };
-
-// 가로모드 토글 기능이 제거되었습니다
 
 // 현재 페이지를 제외한 다른 페이지들 가져오기
 export const getOtherRoutes = (currentPath) => {

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -21,6 +21,13 @@ export const routeConfig = {
     component: 'LearningPage',
     description: '히라가나 연상 학습을 위한 페이지'
   },
+  '/sentence': {
+    name: '문장 테스트',
+    showInSidebar: true,
+    icon: '📝',
+    component: 'SentenceQuiz',
+    description: '히라가나 문장을 입력하고 테스트하는 페이지'
+  },
   '/settings': {
     name: '설정',
     showInSidebar: false,

--- a/src/config/variables.css
+++ b/src/config/variables.css
@@ -37,6 +37,16 @@
   --color-border-light: #ddd;
   --color-border-medium: #bbb;
   --color-border-dark: #999;
+  --color-border: #ddd;
+  
+  /* 표면 색상 */
+  --color-surface: #ffffff;
+  
+  /* 회색 팔레트 */
+  --color-gray-50: #f9fafb;
+  --color-gray-100: #f3f4f6;
+  --color-gray-200: #e5e7eb;
+  --color-gray-300: #d1d5db;
   
   /* 벚꽃 분홍 - 프라이머리 색상 */
   --color-primary: #e8a5c0;
@@ -45,6 +55,8 @@
   
   /* 벚꽃 연두 - 성공 색상 */
   --color-success: #9bc5a2;
+  --color-success-dark: #7a9a82;
+  --color-success-light: #f0f7f1;
   --color-success-border: #7a9a82;
   --color-success-bg: #f0f7f1;
   --color-green-light-alt: #e5f2e7;
@@ -53,6 +65,8 @@
   
   /* 부드러운 연분홍 - 위험 색상 */
   --color-danger: #e8a5a5;
+  --color-danger-dark: #c58a8a;
+  --color-danger-light: #f7f0f0;
   --color-danger-border: #c58a8a;
   --color-danger-bg: #f7f0f0;
   --color-red-light-alt: #f2e5e5;
@@ -89,4 +103,11 @@
   --gradient-green-emerald: linear-gradient(135deg, #2ecc71, #27ae60);
   --gradient-blue-purple: linear-gradient(135deg, #8a2be2, #9370db);
   --gradient-red-pink: linear-gradient(135deg, #e74c3c, #ec7063);
+  
+  /* 그림자 효과 */
+  --shadow-light: 0 2px 8px rgba(0, 0, 0, 0.1);
+  --shadow-medium: 0 4px 16px rgba(0, 0, 0, 0.15);
+  
+  /* 폰트 */
+  --font-family: 'Noto Sans KR', 'Noto Sans JP', sans-serif;
 } 

--- a/src/config/variables.css
+++ b/src/config/variables.css
@@ -105,10 +105,24 @@
   --gradient-blue-purple: linear-gradient(135deg, #8a2be2, #9370db);
   --gradient-red-pink: linear-gradient(135deg, #e74c3c, #ec7063);
   
+    /* 피드백 색상 - 정답/오답 */
+  --color-feedback-correct-bg: linear-gradient(135deg, #d4f6d4, #b8e6b8);
+  --color-feedback-correct-text: #2d5a2d;
+  --color-feedback-correct-border: #4caf50;
+  --color-feedback-correct-shadow: rgba(76, 175, 80, 0.3);
+  
+  --color-feedback-incorrect-bg: linear-gradient(135deg, #ffd4d4, #ffb8b8);
+  --color-feedback-incorrect-text: #8b2635;
+  --color-feedback-incorrect-border: #f44336;
+  --color-feedback-incorrect-shadow: rgba(244, 67, 54, 0.3);
+
+  /* Primary 색상 투명도 변형 */
+  --color-primary-focus-shadow: rgba(59, 130, 246, 0.1);
+
   /* 그림자 효과 */
   --shadow-light: 0 2px 8px rgba(0, 0, 0, 0.1);
   --shadow-medium: 0 4px 16px rgba(0, 0, 0, 0.15);
-  
+
   /* 폰트 */
   --font-family: 'Noto Sans KR', 'Noto Sans JP', sans-serif;
 } 

--- a/src/config/variables.css
+++ b/src/config/variables.css
@@ -67,6 +67,7 @@
   --color-danger: #e8a5a5;
   --color-danger-dark: #c58a8a;
   --color-danger-light: #f7f0f0;
+  --color-danger-lighter: #faf5f5;
   --color-danger-border: #c58a8a;
   --color-danger-bg: #f7f0f0;
   --color-red-light-alt: #f2e5e5;

--- a/src/utils/hiraganaUtils.js
+++ b/src/utils/hiraganaUtils.js
@@ -51,6 +51,25 @@ const hiraganaMap = (() => {
 // 캐시된 히라가나 맵 반환
 export const getAllHiraganaMap = () => hiraganaMap;
 
+// 정적 패턴 배열들 - 모듈 레벨에서 한 번만 생성
+const youonPatterns = [
+  'きゃ', 'きゅ', 'きょ',
+  'しゃ', 'しゅ', 'しょ',
+  'ちゃ', 'ちゅ', 'ちょ',
+  'にゃ', 'にゅ', 'にょ',
+  'ひゃ', 'ひゅ', 'ひょ',
+  'みゃ', 'みゅ', 'みょ',
+  'りゃ', 'りゅ', 'りょ',
+  'ぎゃ', 'ぎゅ', 'ぎょ',
+  'じゃ', 'じゅ', 'じょ',
+  'びゃ', 'びゅ', 'びょ',
+  'ぴゃ', 'ぴゅ', 'ぴょ'
+];
+
+const dakutenPatterns = ['が', 'ぎ', 'ぐ', 'げ', 'ご', 'ざ', 'じ', 'ず', 'ぜ', 'ぞ', 'だ', 'ぢ', 'づ', 'で', 'ど', 'ば', 'び', 'ぶ', 'べ', 'ぼ'];
+
+const handakutenPatterns = ['ぱ', 'ぴ', 'ぷ', 'ぺ', 'ぽ'];
+
 // 히라가나 문자인지 확인하는 함수
 export const isHiragana = (char) => {
   return hiraganaMap.hasOwnProperty(char);
@@ -116,30 +135,15 @@ export const checkAnswer = (userAnswer, correctAnswer) => {
 
 // 요음 패턴 확인
 export const isYouon = (hiragana) => {
-  const youonPatterns = [
-    'きゃ', 'きゅ', 'きょ',
-    'しゃ', 'しゅ', 'しょ',
-    'ちゃ', 'ちゅ', 'ちょ',
-    'にゃ', 'にゅ', 'にょ',
-    'ひゃ', 'ひゅ', 'ひょ',
-    'みゃ', 'みゅ', 'みょ',
-    'りゃ', 'りゅ', 'りょ',
-    'ぎゃ', 'ぎゅ', 'ぎょ',
-    'じゃ', 'じゅ', 'じょ',
-    'びゃ', 'びゅ', 'びょ',
-    'ぴゃ', 'ぴゅ', 'ぴょ'
-  ];
   return youonPatterns.includes(hiragana);
 };
 
 // 탁음 패턴 확인
 export const isDakuten = (hiragana) => {
-  const dakutenPatterns = ['が', 'ぎ', 'ぐ', 'げ', 'ご', 'ざ', 'じ', 'ず', 'ぜ', 'ぞ', 'だ', 'ぢ', 'づ', 'で', 'ど', 'ば', 'び', 'ぶ', 'べ', 'ぼ'];
   return dakutenPatterns.includes(hiragana);
 };
 
 // 반탁음 패턴 확인
 export const isHandakuten = (hiragana) => {
-  const handakutenPatterns = ['ぱ', 'ぴ', 'ぷ', 'ぺ', 'ぽ'];
   return handakutenPatterns.includes(hiragana);
 }; 

--- a/src/utils/hiraganaUtils.js
+++ b/src/utils/hiraganaUtils.js
@@ -5,15 +5,15 @@ import {
   youonData 
 } from '../components/quiz/preparation/hiragana-table/extendedHiraganaData';
 
-// 모든 히라가나 문자와 로마자를 매핑하는 맵 생성
-export const getAllHiraganaMap = () => {
-  const hiraganaMap = {};
+// 모든 히라가나 문자와 로마자를 매핑하는 맵을 모듈 레벨에서 한 번만 생성
+const hiraganaMap = (() => {
+  const map = {};
   
   // 기본 50음도 추가
   basicHiraganaData.forEach(row => {
     row.characters.forEach(char => {
       if (char) {
-        hiraganaMap[char.hiragana] = char.romaji;
+        map[char.hiragana] = char.romaji;
       }
     });
   });
@@ -22,7 +22,7 @@ export const getAllHiraganaMap = () => {
   dakutenData.forEach(row => {
     row.characters.forEach(char => {
       if (char) {
-        hiraganaMap[char.hiragana] = char.romaji;
+        map[char.hiragana] = char.romaji;
       }
     });
   });
@@ -31,7 +31,7 @@ export const getAllHiraganaMap = () => {
   handakutenData.forEach(row => {
     row.characters.forEach(char => {
       if (char) {
-        hiraganaMap[char.hiragana] = char.romaji;
+        map[char.hiragana] = char.romaji;
       }
     });
   });
@@ -40,23 +40,24 @@ export const getAllHiraganaMap = () => {
   youonData.forEach(row => {
     row.characters.forEach(char => {
       if (char) {
-        hiraganaMap[char.hiragana] = char.romaji;
+        map[char.hiragana] = char.romaji;
       }
     });
   });
   
-  return hiraganaMap;
-};
+  return Object.freeze(map); // 불변성 보장
+})();
+
+// 캐시된 히라가나 맵 반환
+export const getAllHiraganaMap = () => hiraganaMap;
 
 // 히라가나 문자인지 확인하는 함수
 export const isHiragana = (char) => {
-  const hiraganaMap = getAllHiraganaMap();
   return hiraganaMap.hasOwnProperty(char);
 };
 
 // 문장에서 히라가나 문자들만 추출하는 함수
 export const extractHiraganaFromSentence = (sentence) => {
-  const hiraganaMap = getAllHiraganaMap();
   const characters = [];
   
   for (let i = 0; i < sentence.length; i++) {
@@ -133,7 +134,6 @@ export const isYouon = (hiragana) => {
 
 // 탁음 패턴 확인
 export const isDakuten = (hiragana) => {
-  const dakutenMap = getAllHiraganaMap();
   const dakutenPatterns = ['が', 'ぎ', 'ぐ', 'げ', 'ご', 'ざ', 'じ', 'ず', 'ぜ', 'ぞ', 'だ', 'ぢ', 'づ', 'で', 'ど', 'ば', 'び', 'ぶ', 'べ', 'ぼ'];
   return dakutenPatterns.includes(hiragana);
 };

--- a/src/utils/hiraganaUtils.js
+++ b/src/utils/hiraganaUtils.js
@@ -1,0 +1,145 @@
+import { 
+  basicHiraganaData, 
+  dakutenData, 
+  handakutenData, 
+  youonData 
+} from '../components/quiz/preparation/hiragana-table/extendedHiraganaData';
+
+// 모든 히라가나 문자와 로마자를 매핑하는 맵 생성
+export const getAllHiraganaMap = () => {
+  const hiraganaMap = {};
+  
+  // 기본 50음도 추가
+  basicHiraganaData.forEach(row => {
+    row.characters.forEach(char => {
+      if (char) {
+        hiraganaMap[char.hiragana] = char.romaji;
+      }
+    });
+  });
+  
+  // 탁음 추가
+  dakutenData.forEach(row => {
+    row.characters.forEach(char => {
+      if (char) {
+        hiraganaMap[char.hiragana] = char.romaji;
+      }
+    });
+  });
+  
+  // 반탁음 추가
+  handakutenData.forEach(row => {
+    row.characters.forEach(char => {
+      if (char) {
+        hiraganaMap[char.hiragana] = char.romaji;
+      }
+    });
+  });
+  
+  // 요음 추가
+  youonData.forEach(row => {
+    row.characters.forEach(char => {
+      if (char) {
+        hiraganaMap[char.hiragana] = char.romaji;
+      }
+    });
+  });
+  
+  return hiraganaMap;
+};
+
+// 히라가나 문자인지 확인하는 함수
+export const isHiragana = (char) => {
+  const hiraganaMap = getAllHiraganaMap();
+  return hiraganaMap.hasOwnProperty(char);
+};
+
+// 문장에서 히라가나 문자들만 추출하는 함수
+export const extractHiraganaFromSentence = (sentence) => {
+  const hiraganaMap = getAllHiraganaMap();
+  const characters = [];
+  
+  for (let i = 0; i < sentence.length; i++) {
+    const char = sentence[i];
+    
+    // 요음 체크 (2글자) - 먼저 확인
+    if (i < sentence.length - 1) {
+      const twoChar = sentence.slice(i, i + 2);
+      if (hiraganaMap[twoChar]) {
+        characters.push({
+          hiragana: twoChar,
+          romaji: hiraganaMap[twoChar],
+          position: i,
+          length: 2
+        });
+        i++; // 다음 글자 건너뛰기
+        continue;
+      }
+    }
+    
+    // 일반 히라가나 체크 (1글자)
+    if (hiraganaMap[char]) {
+      characters.push({
+        hiragana: char,
+        romaji: hiraganaMap[char],
+        position: i,
+        length: 1
+      });
+    }
+  }
+  
+  return characters;
+};
+
+// 문장의 유효성 검사 (히라가나 문자가 포함되어 있는지)
+export const validateHiraganaSentence = (sentence) => {
+  const hiraganaCharacters = extractHiraganaFromSentence(sentence);
+  return {
+    isValid: hiraganaCharacters.length > 0,
+    characterCount: hiraganaCharacters.length,
+    characters: hiraganaCharacters
+  };
+};
+
+// 로마자 표기 정규화 (대소문자 통일, 공백 제거)
+export const normalizeRomaji = (romaji) => {
+  return romaji.toLowerCase().trim();
+};
+
+// 답안 검증 함수
+export const checkAnswer = (userAnswer, correctAnswer) => {
+  const normalizedUser = normalizeRomaji(userAnswer);
+  const normalizedCorrect = normalizeRomaji(correctAnswer);
+  return normalizedUser === normalizedCorrect;
+};
+
+// 요음 패턴 확인
+export const isYouon = (hiragana) => {
+  const youonPatterns = [
+    'きゃ', 'きゅ', 'きょ',
+    'しゃ', 'しゅ', 'しょ',
+    'ちゃ', 'ちゅ', 'ちょ',
+    'にゃ', 'にゅ', 'にょ',
+    'ひゃ', 'ひゅ', 'ひょ',
+    'みゃ', 'みゅ', 'みょ',
+    'りゃ', 'りゅ', 'りょ',
+    'ぎゃ', 'ぎゅ', 'ぎょ',
+    'じゃ', 'じゅ', 'じょ',
+    'びゃ', 'びゅ', 'びょ',
+    'ぴゃ', 'ぴゅ', 'ぴょ'
+  ];
+  return youonPatterns.includes(hiragana);
+};
+
+// 탁음 패턴 확인
+export const isDakuten = (hiragana) => {
+  const dakutenMap = getAllHiraganaMap();
+  const dakutenPatterns = ['が', 'ぎ', 'ぐ', 'げ', 'ご', 'ざ', 'じ', 'ず', 'ぜ', 'ぞ', 'だ', 'ぢ', 'づ', 'で', 'ど', 'ば', 'び', 'ぶ', 'べ', 'ぼ'];
+  return dakutenPatterns.includes(hiragana);
+};
+
+// 반탁음 패턴 확인
+export const isHandakuten = (hiragana) => {
+  const handakutenPatterns = ['ぱ', 'ぴ', 'ぷ', 'ぺ', 'ぽ'];
+  return handakutenPatterns.includes(hiragana);
+}; 


### PR DESCRIPTION
## 📝 새로운 기능 추가

### 🎯 주요 변경사항

#### 1. 히라가나 문장 테스트 기능 구현
- **문장 입력 지원**: 사용자가 직접 히라가나 문장을 입력할 수 있는 인터페이스 제공
- **요음(拗音) 완벽 지원**: きゃ, しゅ, ちょ 등의 복합 문자 정확히 인식 및 처리
- **스마트 문자 분석**: 입력된 문장에서 히라가나 문자들을 자동으로 추출하고 분류
- **랜덤 퀴즈 생성**: 추출된 문자들을 섞어서 개별적으로 테스트

#### 2. 사이드바 리셋 기능 구현
- **페이지 초기화**: 사이드바에서 현재 페이지 메뉴를 재클릭 시 초기 상태로 완전 리셋
- **깔끔한 URL 유지**: 쿼리 파라미터 없이 내부 state로 리셋 처리
- **모든 페이지 지원**: 퀴즈, 문장 테스트, 학습 페이지 모두에서 작동

### 🛠 기술적 구현

#### 새로운 컴포넌트
- **`SentenceQuiz.jsx`**: 문장 기반 테스트 메인 컴포넌트
- **`SentenceQuiz.module.css`**: 전용 스타일링 및 애니메이션
- **`hiraganaUtils.js`**: 히라가나 처리 유틸리티 함수

#### 핵심 기능
```javascript
// 요음 우선 인식 로직
const extractHiraganaFromSentence = (sentence) => {
  // 2글자 요음 먼저 체크 → 1글자 기본음 체크
  // 예: "しゅくだい" → ["しゅ", "く", "だ", "い"]
}

// 사이드바 리셋 기능
const handleNavigate = (path) => {
  if (location.pathname === path) {
    onReset(); // 컴포넌트 재마운트
  }
}
```

### 🎨 UX 개선사항

#### 시각적 피드백 강화
- **정답**: 초록색 그라디언트 + 펄스 애니메이션 🎉
- **오답**: 빨간색 그라디언트 + 흔들림 애니메이션 ❌
- **자동 포커스**: 입력란에 자동 포커스로 즉시 입력 가능

#### 사용자 친화적 인터페이스
- **예시 문장 제공**: 클릭 한 번으로 테스트 시작
- **진행률 표시**: 시각적 프로그레스 바
- **키보드 지원**: Enter 키로 빠른 답안 제출

### 📚 라우팅 및 설정

#### 새로운 라우트
- `/sentence`: 문장 테스트 페이지
- 사이드바 메뉴에 "📝 문장 테스트" 추가

#### CSS 변수 확장
```css
/* 새로운 색상 변수 */
--color-surface: #ffffff;
--color-gray-50: #f9fafb;
--shadow-light: 0 2px 8px rgba(0, 0, 0, 0.1);
--font-family: 'Noto Sans KR', 'Noto Sans JP', sans-serif;
```

### 🚀 사용 방법

1. **사이드바**에서 "📝 문장 테스트" 클릭
2. **히라가나 문장 입력** (예: `おはよう`)
3. **테스트 시작** 버튼 클릭
4. 나타나는 **히라가나 문자의 로마자** 입력
5. **Enter 키** 또는 **제출** 버튼으로 답안 제출

### ✨ 추가 개선사항

- **Footer 링크 업데이트**: 홈페이지 링크를 sinam7.com으로 변경
- **애니메이션 효과**: 정답/오답 시 시각적 피드백 강화
- **반응형 디자인**: 모바일/데스크톱 모두 최적화

---

## 🔍 테스트 완료 사항

- ✅ 기본 히라가나 입력 및 테스트
- ✅ 요음(きゃ, しゅ, ちょ 등) 정확한 인식
- ✅ 사이드바 리셋 기능 모든 페이지에서 작동
- ✅ 자동 포커스 및 키보드 네비게이션
- ✅ 애니메이션 및 시각적 피드백
- ✅ 반응형 디자인

이제 사용자들이 히라가나 문장을 직접 입력하여 연습할 수 있는 완전히 새로운 학습 방식을 제공합니다! 🎌